### PR TITLE
feat: infra tailscale tags updated, disk_gb limit invalid removed

### DIFF
--- a/infra/node1/main.tf
+++ b/infra/node1/main.tf
@@ -23,8 +23,7 @@ resource "tailscale_tailnet_key" "vm_auth_key" {
   preauthorized = true
   expiry        = 3600 # 1 hour validity window
   tags = [
-    "tag:helixscale-cluster",
-    "tag:automation"
+    "tag:helixscale-prod"
   ]
 }
 


### PR DESCRIPTION
tailscale tags are misplaced in provider and need to be in resource. 
Tailscale tags were updated on tailscale end
disk_gb ceiling cannot be enforced by orbstack, removed disk_gb limit